### PR TITLE
docs(readme): remove bugsplat export excerpt

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,6 @@ function App() {
 
 ## API
 
-This package re-exports all exports from
-[bugsplat-js](https://github.com/BugSplat-Git/bugsplat-js).
-
 ### `init()`
 
 ```ts


### PR DESCRIPTION
This package no longer re-export everything from bugsplat-js. This PR just removes an excerpt claiming that we do.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
