### PR TITLE
fix(examples): my-react-crasher fails to load

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
 
       - name: Build Examples
-        run: npm run build:examples
+        run: npm run -w my-react-crasher build:pages
 
       - name: Semantic Release
         env:

--- a/examples/my-react-crasher/package.json
+++ b/examples/my-react-crasher/package.json
@@ -22,6 +22,7 @@
   "private": true,
   "scripts": {
     "build": "vite build",
+    "build:pages": "vite build --mode pages",
     "start": "vite build && npm run symbol-upload && vite preview",
     "symbol-upload": "env-cmd symbol-upload -d ./dist/assets",
     "test": "vitest"

--- a/examples/my-react-crasher/tsconfig.json
+++ b/examples/my-react-crasher/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "vite.config.ts", "vite-env.d.ts"]
 }

--- a/examples/my-react-crasher/vite-env.d.ts
+++ b/examples/my-react-crasher/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vitest" />
 
 interface ImportMetaEnv {
   readonly BUGSPLAT_DATABASE?: string;

--- a/examples/my-react-crasher/vite.config.ts
+++ b/examples/my-react-crasher/vite.config.ts
@@ -1,17 +1,20 @@
-/// <reference types="vitest" />
+/// <reference types="./vite-env" />
 
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
-export default defineConfig({
-  base: "/my-react-crasher/",
-  plugins: [react()],
-  envPrefix: 'BUGSPLAT_',
-  build: {
-    sourcemap: true,
-  },
-  test: {
-    environment: 'jsdom',
-    include: ['./src/**/*.{test,spec}.{ts,tsx}'],
-  },
+export default defineConfig(({mode}) => {
+  return {
+    base: mode === "pages" ? "/my-react-crasher/" : "/",
+    plugins: [react()],
+    envPrefix: 'BUGSPLAT_',
+    build: {
+      sourcemap: true,
+    },
+    test: { 
+      environment: 'jsdom',
+      include: ['./src/**/*.{test,spec}.{ts,tsx}'],
+    },
+  }
 });
+  

--- a/examples/my-react-crasher/vite.config.ts
+++ b/examples/my-react-crasher/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: "/my-react-crasher/",
   plugins: [react()],
   envPrefix: 'BUGSPLAT_',
   build: {


### PR DESCRIPTION
### Description

Here are changes to fix my-react-crasher base url when uploading to github pages. We wanted this url change only when deploying to pages, so I created a script called build:pages that will adjust the base url by calling vite with an alternate mode. 

Fixes #5

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
