### PR TITLE
fix(examples): include pages mode environment file

### DIFF
--- a/examples/my-react-crasher/.env.pages
+++ b/examples/my-react-crasher/.env.pages
@@ -1,0 +1,1 @@
+BUGSPLAT_DATABASE=fred


### PR DESCRIPTION
### Description

Added a .env.pages file with cooresponds with Vite's .env.[mode] convention. It uses dotenv to automatically load environment files when vite commands are run with a specific `--mode`. In our case, `--mode pages` will automatically use this environment file so we can ensure that the build is always passed `BUGSPLAT_DATABASE`.

Fixes # 7

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
