### PR TITLE
chore(cd): upload symbols after build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Build Examples
         run: npm run -w my-react-crasher build:pages
 
+      - name: Upload Symbols
+        run: npm run -w my-react-crasher symbol-upload
+
       - name: Semantic Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

I added a symbol-upload step to the github action workflow, `cd.yml`. This should take care of mismatches we are seeing with uploaded symbols for the sample.

Fixes #9 

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
