### PR TITLE
fix: remove componentStack attachment override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "examples/*"
       ],
       "dependencies": {
-        "bugsplat": "^9.1.0"
+        "bugsplat": "^9.1.1"
       },
       "devDependencies": {
         "@bugsplat/js-api-client": "^2.0.0",
@@ -4154,9 +4154,9 @@
       "license": "MIT"
     },
     "node_modules/bugsplat": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/bugsplat/-/bugsplat-9.1.0.tgz",
-      "integrity": "sha512-QIfY6kMtlMwJQz2Beg42QJ65TgkKP49jv5zBVCX2X86CDdCRFY0i/B9s1k3aqElJMRLVkiWxUut6FRTn2Xx5fQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bugsplat/-/bugsplat-9.1.1.tgz",
+      "integrity": "sha512-uAzCh6lVhfDFctIdXOMlqv4HUsbePDrvLX87KcC6zC8YaZ2SSZfvRxeFJNnoUc4aui0aqY3uCMKSz1lo5x0oxg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "author": "zmrl",
   "license": "MIT",
   "dependencies": {
-    "bugsplat": "^9.1.0"
+    "bugsplat": "^9.1.1"
   },
   "devDependencies": {
     "@bugsplat/js-api-client": "^2.0.0",

--- a/spec/ErrorBoundary.spec.tsx
+++ b/spec/ErrorBoundary.spec.tsx
@@ -166,6 +166,7 @@ describe('<ErrorBoundary />', () => {
         const [attachment] = options.attachments;
         expect(attachment.filename).toBe('componentStack.txt');
         expect(attachment.data).toBeInstanceOf(Blob);
+        expect(attachment.data.type).toBe('text/plain');
       });
 
       it('should call beforePost', async () => {

--- a/spec/ErrorBoundary.spec.tsx
+++ b/spec/ErrorBoundary.spec.tsx
@@ -152,7 +152,7 @@ describe('<ErrorBoundary />', () => {
         await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
       });
 
-      it('should attach componentStack as a text/plain Blob by default', async () => {
+      it('should attach componentStack as a Blob', async () => {
         render(
           <ErrorBoundary scope={scope} fallback={BasicFallback}>
             <BlowUp />
@@ -166,25 +166,6 @@ describe('<ErrorBoundary />', () => {
         const [attachment] = options.attachments;
         expect(attachment.filename).toBe('componentStack.txt');
         expect(attachment.data).toBeInstanceOf(Blob);
-        expect(attachment.data.type).toBe('text/plain');
-      });
-
-      it('honors scope.getCreateComponentStackAttachment() when provided', async () => {
-        const customAttachment = { filename: 'componentStack.txt', data: 'CUSTOM' };
-        const customBuilder = jest.fn(() => customAttachment);
-        const scopeWithBuilder = new Scope(bugSplat, customBuilder);
-
-        render(
-          <ErrorBoundary scope={scopeWithBuilder} fallback={BasicFallback}>
-            <BlowUp />
-          </ErrorBoundary>
-        );
-
-        await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
-
-        expect(customBuilder).toHaveBeenCalledWith(expect.stringContaining('BlowUp'));
-        const [, options] = mockPost.mock.calls[0];
-        expect(options.attachments).toEqual([customAttachment]);
       });
 
       it('should call beforePost', async () => {

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,6 +1,5 @@
 import {
   type BugSplat,
-  type BugSplatAttachment,
   type BugSplatResponse,
 } from 'bugsplat';
 import {
@@ -11,8 +10,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react';
-import { appScope } from './appScope';
-import type { Scope } from './scope';
+import { getBugSplat } from './appScope';
 
 /**
  * Shallowly compare two arrays to determine if they are different.
@@ -139,7 +137,7 @@ interface InternalErrorBoundaryProps {
    * to pass their own scope that will inject the client for use by
    * ErrorBoundary.
    */
-  scope: Pick<Scope, 'getClient' | 'getCreateComponentStackAttachment'>;
+  scope: { getClient(): BugSplat | null };
 }
 
 export type ErrorBoundaryProps = JSX.LibraryManagedAttributes<
@@ -199,7 +197,7 @@ export class ErrorBoundary extends Component<
     onResetKeysChange: noop,
     onUnmount: noop,
     disablePost: false,
-    scope: appScope,
+    scope: { getClient: getBugSplat },
   };
 
   state = INITIAL_STATE;
@@ -247,7 +245,7 @@ export class ErrorBoundary extends Component<
 
     return client.post(error, {
       attachments: componentStack
-        ? [scope.getCreateComponentStackAttachment()(componentStack)]
+        ? [{ filename: 'componentStack.txt', data: new Blob([componentStack]) }]
         : [],
     });
   }

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -245,7 +245,7 @@ export class ErrorBoundary extends Component<
 
     return client.post(error, {
       attachments: componentStack
-        ? [{ filename: 'componentStack.txt', data: new Blob([componentStack]) }]
+        ? [{ filename: 'componentStack.txt', data: new Blob([componentStack], { type: 'text/plain' }) }]
         : [],
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ export type {
 
 export * from './appScope';
 export * from './ErrorBoundary';
-export * from './scope';
 export * from './useErrorHandler';
 export * from './useFeedback';
 export * from './withErrorBoundary';

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,30 +1,10 @@
-import type { BugSplat, BugSplatAttachment } from 'bugsplat';
+import type { BugSplat } from 'bugsplat';
 
 /**
- * Builds the componentStack attachment for ErrorBoundary posts.
- */
-export type CreateComponentStackAttachment = (
-  componentStack: string
-) => BugSplatAttachment;
-
-/**
- * Default builder — wraps the stack in a `text/plain` `Blob`.
- */
-export const defaultCreateComponentStackAttachment: CreateComponentStackAttachment = (
-  componentStack
-) => ({
-  filename: 'componentStack.txt',
-  data: new Blob([componentStack], { type: 'text/plain' }),
-});
-
-/**
- * Encapsulate BugSplat client instance and scope-level overrides.
+ * Encapsulate BugSplat client instance
  */
 export class Scope {
-  constructor(
-    private client: BugSplat | null = null,
-    private createComponentStackAttachment: CreateComponentStackAttachment = defaultCreateComponentStackAttachment
-  ) {}
+  constructor(private client: BugSplat | null = null) {}
 
   /**
    * @returns BugSplat client instance or null if unset
@@ -35,16 +15,5 @@ export class Scope {
 
   setClient(client: BugSplat) {
     this.client = client;
-  }
-
-  /**
-   * @returns the current componentStack attachment builder
-   */
-  getCreateComponentStackAttachment() {
-    return this.createComponentStackAttachment;
-  }
-
-  setCreateComponentStackAttachment(fn: CreateComponentStackAttachment) {
-    this.createComponentStackAttachment = fn;
   }
 }


### PR DESCRIPTION
## Summary
- Removes `setCreateComponentStackAttachment` / `getCreateComponentStackAttachment` from `Scope`
- Reverts `Scope` to its original shape (just holds the BugSplat client)
- Uses inline `new Blob([componentStack])` in `ErrorBoundary.dispatchPost()`
- Removes `Scope` and `CreateComponentStackAttachment` from public exports

The override mechanism was added to work around RN's `Blob` not serializing correctly in `FormData` + `fetch`. The actual fix is `expo-blob` — a web-standards-compliant `Blob` polyfill for React Native (part of Expo SDK 55). With `@bugsplat/expo` importing `expo-blob`, the default `new Blob()` works correctly on both web and native, making the override unnecessary.

## Test plan
- [x] All 19 unit tests pass
- [x] Integration test (requires env vars, runs in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)